### PR TITLE
墓システムの原型を作成

### DIFF
--- a/TUSBAD_Prototype/data/api/function/load.mcfunction
+++ b/TUSBAD_Prototype/data/api/function/load.mcfunction
@@ -37,7 +37,7 @@ scoreboard objectives add set_health_amount dummy
 scoreboard objectives add set_heal_amount dummy
 
 # 乱数取得用
-scoreboard objectives add randomNum dummy
+scoreboard objectives add random_num dummy
 
 # calc計算用スコアボード
 

--- a/TUSBAD_Prototype/data/api/function/random/random_int.mcfunction
+++ b/TUSBAD_Prototype/data/api/function/random/random_int.mcfunction
@@ -2,9 +2,9 @@
 # 最大値、最小値を設定することでランダムな整数値を取得する
 
 #乱数に使う数の代入
-$execute as @a run scoreboard players set _randCalcMan calc1 $(max)
+$execute as @a run scoreboard players set $rand_calc calc1 $(max)
 
-$execute as @a run scoreboard players set _randCalcMan calc2 $(min)
+$execute as @a run scoreboard players set $rand_calc calc2 $(min)
 
 #乱数計算の準備
 
@@ -12,19 +12,19 @@ $execute as @a run scoreboard players set _randCalcMan calc2 $(min)
 execute at @a run summon minecraft:armor_stand ~ ~ ~ {Marker:1b,Invisible:1b,Tags:['rnd']}
 
 #アーマースタンドからUUIDを取得
-execute as @a store result score _randCalcMan random_num run data get entity @e[tag=rnd, sort=nearest, limit=1] UUID[0]
+execute as @a store result score $rand_calc random_num run data get entity @e[tag=rnd, sort=nearest, limit=1] UUID[0]
 
 #乱数を剰余で計算
-execute as @a run scoreboard players operation _randCalcMan random_num %= _randCalcMan calc1
+execute as @a run scoreboard players operation $rand_calc random_num %= $rand_calc calc1
 
 #最低値で補正
-execute as @a run scoreboard players operation _randCalcMan random_num += _randCalcMan calc2
+execute as @a run scoreboard players operation $rand_calc random_num += $rand_calc calc2
 
 #最大値が最小値より小さい場合は同じにする
-execute as @a if score _randCalcMan calc1 <= _randCalcMan calc2 run scoreboard players operation _randCalcMan random_num = _randCalcMan calc2
+execute as @a if score $rand_calc calc1 <= $rand_calc calc2 run scoreboard players operation $rand_calc random_num = $rand_calc calc2
 
 #乱数値をストレージに保存
-execute store result storage tusb_ad:api rand int 1 run scoreboard players get _randCalcMan random_num
+execute store result storage tusb_ad:api rand int 1 run scoreboard players get $rand_calc random_num
 
 #乱数用のアマスタを削除
 kill @e[tag=rnd]

--- a/TUSBAD_Prototype/data/api/function/random/random_int.mcfunction
+++ b/TUSBAD_Prototype/data/api/function/random/random_int.mcfunction
@@ -12,19 +12,19 @@ $execute as @a run scoreboard players set _randCalcMan calc2 $(min)
 execute at @a run summon minecraft:armor_stand ~ ~ ~ {Marker:1b,Invisible:1b,Tags:['rnd']}
 
 #アーマースタンドからUUIDを取得
-execute as @a store result score _randCalcMan randomNum run data get entity @e[tag=rnd, sort=nearest, limit=1] UUID[0]
+execute as @a store result score _randCalcMan random_num run data get entity @e[tag=rnd, sort=nearest, limit=1] UUID[0]
 
 #乱数を剰余で計算
-execute as @a run scoreboard players operation _randCalcMan randomNum %= _randCalcMan calc1
+execute as @a run scoreboard players operation _randCalcMan random_num %= _randCalcMan calc1
 
 #最低値で補正
-execute as @a run scoreboard players operation _randCalcMan randomNum += _randCalcMan calc2
+execute as @a run scoreboard players operation _randCalcMan random_num += _randCalcMan calc2
 
 #最大値が最小値より小さい場合は同じにする
-execute as @a if score _randCalcMan calc1 <= _randCalcMan calc2 run scoreboard players operation _randCalcMan randomNum = _randCalcMan calc2
+execute as @a if score _randCalcMan calc1 <= _randCalcMan calc2 run scoreboard players operation _randCalcMan random_num = _randCalcMan calc2
 
 #乱数値をストレージに保存
-execute store result storage tusb_ad:api rand int 1 run scoreboard players get _randCalcMan randomNum
+execute store result storage tusb_ad:api rand int 1 run scoreboard players get _randCalcMan random_num
 
 #乱数用のアマスタを削除
 kill @e[tag=rnd]

--- a/TUSBAD_Prototype/data/player_manager/function/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/.mcfunction
@@ -2,10 +2,10 @@
 # プレイヤー周りのセットアップ処理を行う
 
 # 墓の総数カウント
-scoreboard objectives add TombCount dummy
+scoreboard objectives add tomb_count dummy
 
 # 墓数計算用スコアボード
-scoreboard objectives add TombCalc dummy
+scoreboard objectives add tomb_calc dummy
 
 # 墓の総数が０以下なら０に戻す
-#execute if score $TombCounter TombCount matches ..0 run scoreboard players set $TombCounter TombCount 0
+#execute if score $TombCounter tomb_count matches ..0 run scoreboard players set $TombCounter tomb_count 0

--- a/TUSBAD_Prototype/data/player_manager/function/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/.mcfunction
@@ -1,0 +1,11 @@
+#> player_manager:
+# プレイヤー周りのセットアップ処理を行う
+
+# 墓の総数カウント
+scoreboard objectives add TombCount dummy
+
+# 墓数計算用スコアボード
+scoreboard objectives add TombCalc dummy
+
+# 墓の総数が０以下なら０に戻す
+#execute if score $TombCounter TombCount matches ..0 run scoreboard players set $TombCounter TombCount 0

--- a/TUSBAD_Prototype/data/player_manager/function/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/.mcfunction
@@ -8,4 +8,4 @@ scoreboard objectives add tomb_count dummy
 scoreboard objectives add tomb_calc dummy
 
 # 墓の総数が０以下なら０に戻す
-#execute if score $TombCounter tomb_count matches ..0 run scoreboard players set $TombCounter tomb_count 0
+#execute if score $tomb_counter tomb_count matches ..0 run scoreboard players set $tomb_counter tomb_count 0

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/.mcfunction
@@ -9,11 +9,11 @@ data modify storage tusb_ad:player_manager isTombDifficult set value 0
 execute store result storage tusb_ad:player_manager isKeepInventory int 1 run gamerule keepInventory
 
 #キープインベントリがONである、かつ墓システムが有効な難易度であれば墓の処理を実行するフラグを立てる
-execute if data storage tusb_ad:player_manager {isKeepInventory:1} if data storage core: difficult{world:"debug"} run data modify storage tusb_ad:player_manager isTombDifficult set value 1
+execute if data storage tusb_ad:player_manager {isKeepInventory:1} if data storage world_manager: difficult{world:"debug"} run data modify storage tusb_ad:player_manager isTombDifficult set value 1
 
 #execute if data storage tusb_ad:player_manager {isKeepInventory:1} if data storage core: difficult{world:"picnic"} run data modify storage tusb_ad:player_manager isTombDifficult set value 0
 
-execute if data storage tusb_ad:player_manager {isKeepInventory:1} if data storage core: difficult{world:"casual"} run data modify storage tusb_ad:player_manager isTombDifficult set value 1
+execute if data storage tusb_ad:player_manager {isKeepInventory:1} if data storage world_manager: difficult{world:"casual"} run data modify storage tusb_ad:player_manager isTombDifficult set value 1
 
 #execute if data storage tusb_ad:player_manager {isKeepInventory:1} if data storage core: difficult{world:"another"} run data modify storage tusb_ad:player_manager isTombDifficult set value 0
 

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/.mcfunction
@@ -1,0 +1,20 @@
+#> player_manager:tomb/
+# 死亡時に呼び出され、墓処理を行う
+
+#キープインベントリや墓の検知状況をリセット
+data modify storage tusb_ad:player_manager isKeepInventory set value 0
+data modify storage tusb_ad:player_manager isTombDifficult set value 0
+
+#キープインベントリかどうかを検知
+execute store result storage tusb_ad:player_manager isKeepInventory int 1 run gamerule keepInventory
+
+#キープインベントリがONである、かつ墓システムが有効な難易度であれば墓の処理を実行するフラグを立てる
+execute if data storage tusb_ad:player_manager {isKeepInventory:1} if data storage core: difficult{world:"debug"} run data modify storage tusb_ad:player_manager isTombDifficult set value 1
+
+#execute if data storage tusb_ad:player_manager {isKeepInventory:1} if data storage core: difficult{world:"picnic"} run data modify storage tusb_ad:player_manager isTombDifficult set value 0
+
+execute if data storage tusb_ad:player_manager {isKeepInventory:1} if data storage core: difficult{world:"casual"} run data modify storage tusb_ad:player_manager isTombDifficult set value 1
+
+#execute if data storage tusb_ad:player_manager {isKeepInventory:1} if data storage core: difficult{world:"another"} run data modify storage tusb_ad:player_manager isTombDifficult set value 0
+
+#execute if data storage tusb_ad:player_manager {isKeepInventory:1} if data storage core: difficult{world:"hardcore"} run data modify storage tusb_ad:player_manager isTombDifficult set value 0

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/death_item_storage.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/death_item_storage.mcfunction
@@ -8,7 +8,7 @@ execute if data storage tusb_ad:player_manager {isTombDifficult:1} run function 
 function #oh_my_dat:please
 
 #インベントリが空でない状態で保存処理が行われたら墓の数を一つ増やす
-execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run scoreboard players add $TombCounter TombCount 1
+execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run scoreboard players add $TombCounter tomb_count 1
 
 #保存したストレージを死亡ストレージの末尾に追加（インベントリが空であれば弾く）
 execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run data modify storage tusb_ad:player_manager tomb[-1] append from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/death_item_storage.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/death_item_storage.mcfunction
@@ -1,0 +1,15 @@
+#> player_manager:tomb/death_item_storage
+# 死亡時に呼び出され、死亡時のアイテムを保存し、ストレージに加える
+
+#アイテムを保存（この時点でキープインベントリであることが確定しているため通常保存で保存可能なはず）
+execute if data storage tusb_ad:player_manager {isTombDifficult:1} run function player_manager:update/player_dat/player_common/inventory/
+
+#個人ストレージを呼び出し
+function #oh_my_dat:please
+
+#インベントリが空でない状態で保存処理が行われたら墓の数を一つ増やす
+execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run scoreboard players add $TombCounter TombCount 1
+
+#保存したストレージを死亡ストレージの末尾に追加（インベントリが空であれば弾く）
+execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run data modify storage tusb_ad:player_manager tomb[-1] append from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory
+

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/death_item_storage.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/death_item_storage.mcfunction
@@ -8,7 +8,7 @@ execute if data storage tusb_ad:player_manager {isTombDifficult:1} run function 
 function #oh_my_dat:please
 
 #インベントリが空でない状態で保存処理が行われたら墓の数を一つ増やす
-execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run scoreboard players add $TombCounter tomb_count 1
+execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run scoreboard players add $tomb_counter tomb_count 1
 
 #保存したストレージを死亡ストレージの末尾に追加（インベントリが空であれば弾く）
 execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run data modify storage tusb_ad:player_manager tomb[-1] append from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/return_calc.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/return_calc.mcfunction
@@ -3,20 +3,20 @@
 
 #取り返す数を算出
 #半数を求める
-scoreboard players operation $TombCounter TombCalc = $TombCounter TombCount
-scoreboard players set $TombCounterCalc TombCalc 2
-scoreboard players operation $TombCounter TombCalc /= $TombCounterCalc TombCalc
+scoreboard players operation $TombCounter tomb_calc = $TombCounter tomb_count
+scoreboard players set $TombCounterCalc tomb_calc 2
+scoreboard players operation $TombCounter tomb_calc /= $TombCounterCalc tomb_calc
 
 #余りを求める
-scoreboard players operation $TombCounterCalc TombCount = $TombCounter TombCount
-scoreboard players operation $TombCounterCalc TombCount %= $TombCounterCalc TombCalc
-scoreboard players operation $TombCounter TombCalc += $TombCounterCalc TombCount
+scoreboard players operation $TombCounterCalc tomb_count = $TombCounter tomb_count
+scoreboard players operation $TombCounterCalc tomb_count %= $TombCounterCalc tomb_calc
+scoreboard players operation $TombCounter tomb_calc += $TombCounterCalc tomb_count
 
 #墓の総数を減算
-scoreboard players operation $TombCounter TombCount -= $TombCounter TombCalc
+scoreboard players operation $TombCounter tomb_count -= $TombCounter tomb_calc
 
 #取り返す
-tellraw @s [{"score":{"name":"$TombCounter","objective":"TombCalc"}},{"text":"個の墓を取り返した！"}]
+tellraw @s [{"score":{"name":"$TombCounter","objective":"tomb_calc"}},{"text":"個の墓を取り返した！"}]
 function player_manager:tomb/return_item
 
 

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/return_calc.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/return_calc.mcfunction
@@ -3,20 +3,20 @@
 
 #取り返す数を算出
 #半数を求める
-scoreboard players operation $TombCounter tomb_calc = $TombCounter tomb_count
-scoreboard players set $TombCounterCalc tomb_calc 2
-scoreboard players operation $TombCounter tomb_calc /= $TombCounterCalc tomb_calc
+scoreboard players operation $tomb_counter tomb_calc = $tomb_counter tomb_count
+scoreboard players set $tomb_counter_calc tomb_calc 2
+scoreboard players operation $tomb_counter tomb_calc /= $tomb_counter_calc tomb_calc
 
 #余りを求める
-scoreboard players operation $TombCounterCalc tomb_count = $TombCounter tomb_count
-scoreboard players operation $TombCounterCalc tomb_count %= $TombCounterCalc tomb_calc
-scoreboard players operation $TombCounter tomb_calc += $TombCounterCalc tomb_count
+scoreboard players operation $tomb_counter_calc tomb_count = $tomb_counter tomb_count
+scoreboard players operation $tomb_counter_calc tomb_count %= $tomb_counter_calc tomb_calc
+scoreboard players operation $tomb_counter tomb_calc += $tomb_counter_calc tomb_count
 
 #墓の総数を減算
-scoreboard players operation $TombCounter tomb_count -= $TombCounter tomb_calc
+scoreboard players operation $tomb_counter tomb_count -= $tomb_counter tomb_calc
 
 #取り返す
-tellraw @s [{"score":{"name":"$TombCounter","objective":"tomb_calc"}},{"text":"個の墓を取り返した！"}]
+tellraw @s [{"score":{"name":"$tomb_counter","objective":"tomb_calc"}},{"text":"個の墓を取り返した！"}]
 function player_manager:tomb/return_item
 
 

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/return_calc.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/return_calc.mcfunction
@@ -1,0 +1,22 @@
+#> player_manager:tomb/return_calc
+# 取り返す墓の数を算出
+
+#取り返す数を算出
+#半数を求める
+scoreboard players operation $TombCounter TombCalc = $TombCounter TombCount
+scoreboard players set $TombCounter_calc TombCalc 2
+scoreboard players operation $TombCounter TombCalc /= $TombCounter_calc TombCalc
+
+#余りを求める
+scoreboard players operation $TombCounter_calc TombCount = $TombCounter TombCount
+scoreboard players operation $TombCounter_calc TombCount %= $TombCounter_calc TombCalc
+scoreboard players operation $TombCounter TombCalc += $TombCounter_calc TombCount
+
+#墓の総数を減算
+scoreboard players operation $TombCounter TombCount -= $TombCounter TombCalc
+
+#取り返す
+tellraw @s [{"score":{"name":"$TombCounter","objective":"TombCalc"}},{"text":"個の墓を取り返した！"}]
+function player_manager:tomb/return_item
+
+

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/return_calc.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/return_calc.mcfunction
@@ -4,13 +4,13 @@
 #取り返す数を算出
 #半数を求める
 scoreboard players operation $TombCounter TombCalc = $TombCounter TombCount
-scoreboard players set $TombCounter_calc TombCalc 2
-scoreboard players operation $TombCounter TombCalc /= $TombCounter_calc TombCalc
+scoreboard players set $TombCounterCalc TombCalc 2
+scoreboard players operation $TombCounter TombCalc /= $TombCounterCalc TombCalc
 
 #余りを求める
-scoreboard players operation $TombCounter_calc TombCount = $TombCounter TombCount
-scoreboard players operation $TombCounter_calc TombCount %= $TombCounter_calc TombCalc
-scoreboard players operation $TombCounter TombCalc += $TombCounter_calc TombCount
+scoreboard players operation $TombCounterCalc TombCount = $TombCounter TombCount
+scoreboard players operation $TombCounterCalc TombCount %= $TombCounterCalc TombCalc
+scoreboard players operation $TombCounter TombCalc += $TombCounterCalc TombCount
 
 #墓の総数を減算
 scoreboard players operation $TombCounter TombCount -= $TombCounter TombCalc

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/return_core.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/return_core.mcfunction
@@ -2,8 +2,8 @@
 # 死んだ総数から半分の墓を古い順に取り返す処理
 
 #墓が０個以下なら弾く
-execute if score $TombCounter tomb_count matches ..0 run say 取り返す墓がないようだ…
+execute if score $tomb_counter tomb_count matches ..0 run say 取り返す墓がないようだ…
 
 #取り返す数を算出
-execute unless score $TombCounter tomb_count matches ..0 run function player_manager:tomb/return_calc
+execute unless score $tomb_counter tomb_count matches ..0 run function player_manager:tomb/return_calc
 

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/return_core.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/return_core.mcfunction
@@ -1,0 +1,9 @@
+#> player_manager:tomb/return_core
+# 死んだ総数から半分の墓を古い順に取り返す処理
+
+#墓が０個以下なら弾く
+execute if score $TombCounter TombCount matches ..0 run say 取り返す墓がないようだ…
+
+#取り返す数を算出
+execute unless score $TombCounter TombCount matches ..0 run function player_manager:tomb/return_calc
+

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/return_core.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/return_core.mcfunction
@@ -2,8 +2,8 @@
 # 死んだ総数から半分の墓を古い順に取り返す処理
 
 #墓が０個以下なら弾く
-execute if score $TombCounter TombCount matches ..0 run say 取り返す墓がないようだ…
+execute if score $TombCounter tomb_count matches ..0 run say 取り返す墓がないようだ…
 
 #取り返す数を算出
-execute unless score $TombCounter TombCount matches ..0 run function player_manager:tomb/return_calc
+execute unless score $TombCounter tomb_count matches ..0 run function player_manager:tomb/return_calc
 

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/return_item.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/return_item.mcfunction
@@ -7,10 +7,10 @@ execute if block ~ ~ ~ chest run data modify block ~ ~ ~ Items set from storage 
 #取り返したストレージを消去
 execute if block ~ ~ ~ chest run say 墓を取りかえした！
 data remove storage tusb_ad:player_manager tomb[0]
-execute if score $TombCounter tomb_calc matches 1.. run scoreboard players remove $TombCounter tomb_calc 1
+execute if score $tomb_counter tomb_calc matches 1.. run scoreboard players remove $tomb_counter tomb_calc 1
 
 #まだ取り返せるなら再起
-execute if score $TombCounter tomb_calc matches 1.. run function player_manager:tomb/return_item
+execute if score $tomb_counter tomb_calc matches 1.. run function player_manager:tomb/return_item
 
 
 

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/return_item.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/return_item.mcfunction
@@ -1,0 +1,16 @@
+#> player_manager:tomb/return_item
+# アイテムを取り返す処理
+
+#一番古い死亡時のアイテムを取り返す
+execute if block ~ ~ ~ chest run data modify block ~ ~ ~ Items set from storage tusb_ad:player_manager tomb[0]
+
+#取り返したストレージを消去
+execute if block ~ ~ ~ chest run say 墓を取りかえした！
+data remove storage tusb_ad:player_manager tomb[0]
+execute if score $TombCounter TombCalc matches 1.. run scoreboard players remove $TombCounter TombCalc 1
+
+#まだ取り返せるなら再起
+execute if score $TombCounter TombCalc matches 1.. run function player_manager:tomb/return_item
+
+
+

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/return_item.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/return_item.mcfunction
@@ -7,10 +7,10 @@ execute if block ~ ~ ~ chest run data modify block ~ ~ ~ Items set from storage 
 #取り返したストレージを消去
 execute if block ~ ~ ~ chest run say 墓を取りかえした！
 data remove storage tusb_ad:player_manager tomb[0]
-execute if score $TombCounter TombCalc matches 1.. run scoreboard players remove $TombCounter TombCalc 1
+execute if score $TombCounter tomb_calc matches 1.. run scoreboard players remove $TombCounter tomb_calc 1
 
 #まだ取り返せるなら再起
-execute if score $TombCounter TombCalc matches 1.. run function player_manager:tomb/return_item
+execute if score $TombCounter tomb_calc matches 1.. run function player_manager:tomb/return_item
 
 
 

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/test/test_save.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/test/test_save.mcfunction
@@ -8,7 +8,7 @@ function player_manager:update/player_dat/player_common/inventory/
 function #oh_my_dat:please
 
 #インベントリが空でない状態で保存処理が行われたら墓の数を一つ増やす
-execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run scoreboard players add $TombCounter TombCount 1
+execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run scoreboard players add $TombCounter tomb_count 1
 
 #保存したストレージを死亡ストレージの末尾に追加（インベントリが空であれば弾く）
 execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run data modify storage tusb_ad:player_manager tomb append from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/test/test_save.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/test/test_save.mcfunction
@@ -8,7 +8,7 @@ function player_manager:update/player_dat/player_common/inventory/
 function #oh_my_dat:please
 
 #インベントリが空でない状態で保存処理が行われたら墓の数を一つ増やす
-execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run scoreboard players add $TombCounter tomb_count 1
+execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run scoreboard players add $tomb_counter tomb_count 1
 
 #保存したストレージを死亡ストレージの末尾に追加（インベントリが空であれば弾く）
 execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run data modify storage tusb_ad:player_manager tomb append from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory

--- a/TUSBAD_Prototype/data/player_manager/function/tomb/test/test_save.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/tomb/test/test_save.mcfunction
@@ -1,0 +1,18 @@
+#> player_manager:tomb/test/test_save
+# テスト用にアイテムをセーブして墓を作る
+
+#アイテムを保存（この時点でキープインベントリであることが確定しているため通常保存で保存可能なはず）
+function player_manager:update/player_dat/player_common/inventory/
+
+#個人ストレージを呼び出し
+function #oh_my_dat:please
+
+#インベントリが空でない状態で保存処理が行われたら墓の数を一つ増やす
+execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run scoreboard players add $TombCounter TombCount 1
+
+#保存したストレージを死亡ストレージの末尾に追加（インベントリが空であれば弾く）
+execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run data modify storage tusb_ad:player_manager tomb append from storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory
+
+#ログ
+execute if data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run say 墓を保存しました
+execute unless data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory[-1] run say アイテムが空なので墓を保存できませんでした...

--- a/TUSBAD_Prototype/data/player_manager/function/update/data_check.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/data_check.mcfunction
@@ -1,7 +1,7 @@
 #> player_manager:update/data_check
 # プレイヤーのデータを毎Tick監視し、変更箇所ごとにデータを保存する
 
-#function oh_my_dat:please
+#function #oh_my_dat:please
 
 #execute unless data storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].setup run data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4] set from entity @s
 

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/air/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/air/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/air/
 # プレイヤーNBT（エンティティ汎用NBT系）、air（空気）を保存する処理
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Air set from entity @s Air

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/fall_distance/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/fall_distance/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/fall_distance/
 # プレイヤーNBT（エンティティ汎用NBT系）、現時点でエンティティが落下している距離
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].FallDistance set from entity @s FallDistance

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/fire/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/fire/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/fire/
 # プレイヤーNBT（エンティティ汎用NBT系）、火が消えるまでのティック数
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Fire set from entity @s Fire

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/has_visual_fire/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/has_visual_fire/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/has_visual_fire/
 # プレイヤーNBT（エンティティ汎用NBT系）、炎上しているように描画するか
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].HasVisualFire set from entity @s HasVisualFire

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/invulnerable/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/invulnerable/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/invulnerable/
 # プレイヤーNBT（エンティティ汎用NBT系）、不死身であるか
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Invulnerable set from entity @s Invulnerable

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/motion/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/motion/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/motion/
 # プレイヤーNBT（エンティティ汎用NBT系）、移動速度
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Motion set from entity @s Motion

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/motion/dx.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/motion/dx.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/motion/dx
 # プレイヤーNBT（エンティティ汎用NBT系）、移動速度（Ｘ軸）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Motion[0] set from entity @s Motion[0]

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/motion/dy.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/motion/dy.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/motion/dy
 # プレイヤーNBT（エンティティ汎用NBT系）、移動速度（Ｙ軸）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Motion[1] set from entity @s Motion[1]

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/motion/dz.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/motion/dz.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/motion/dz
 # プレイヤーNBT（エンティティ汎用NBT系）、移動速度（Ｚ軸）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Motion[2] set from entity @s Motion[2]

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/no_gravity/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/no_gravity/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/no_gravity/
 # プレイヤーNBT（エンティティ汎用NBT系）、無重力状態であるか
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].NoGravity set from entity @s NoGravity

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/on_ground/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/on_ground/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/on_ground/
 # プレイヤーNBT（エンティティ汎用NBT系）、接地状態であるか
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].OnGround set from entity @s OnGround

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/passengers/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/passengers/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/passengers/
 # プレイヤーNBT（エンティティ汎用NBT系）、騎乗したエンティティのデータ
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Passengers set from entity @s Passengers

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/portal_cooldown/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/portal_cooldown/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/portal_cooldown/
 # プレイヤーNBT（エンティティ汎用NBT系）、騎乗したエンティティのデータ
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].PortalCooldown set from entity @s PortalCooldown

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/pos/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/pos/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/pos/
 # プレイヤーNBT（エンティティ汎用NBT系）、座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Pos set from entity @s Pos

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/pos/x.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/pos/x.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/pos/x
 # プレイヤーNBT（エンティティ汎用NBT系）、Ｘ軸の座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Pos[0] set from entity @s Pos[0]

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/pos/y.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/pos/y.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/pos/y
 # プレイヤーNBT（エンティティ汎用NBT系）、Ｙ軸の座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Pos[1] set from entity @s Pos[1]

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/pos/z.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/pos/z.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/pos/z
 # プレイヤーNBT（エンティティ汎用NBT系）、Ｚ軸の座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Pos[2] set from entity @s Pos[2]

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/rotation/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/rotation/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/rotation/
 # プレイヤーNBT（エンティティ汎用NBT系）、回転
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Rotation set from entity @s Rotation

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/rotation/pitch.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/rotation/pitch.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/rotation/pitch
 # プレイヤーNBT（エンティティ汎用NBT系）、ピッチ（地平線からのオフセット）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Rotation[1] set from entity @s Rotation[1]

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/rotation/yaw.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/rotation/yaw.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/rotation/yaw
 # プレイヤーNBT（エンティティ汎用NBT系）、ヨー（Ｙ軸 を中心とした回転。）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Rotation[0] set from entity @s Rotation[0]

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/silent/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/silent/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/silent/
 # プレイヤーNBT（エンティティ汎用NBT系）、ヨー（Ｙ軸 を中心とした回転。）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Silent set from entity @s Silent

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/tags/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/tags/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/tags/
 # プレイヤーNBT（エンティティ汎用NBT系）、付与されているタグ
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Tags set from entity @s Tags

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/ticks_frozen/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/ticks_frozen/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/ticks_frozen/
 # プレイヤーNBT（エンティティ汎用NBT系）、凍結されている時間
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].TicksFrozen set from entity @s TicksFrozen

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/uuid/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/entity_common/uuid/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/entity_common/uuid/
 # プレイヤーNBT（エンティティ汎用NBT系）、固有の識別ID（UUID）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].UUID set from entity @s UUID

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/absorption_amount/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/absorption_amount/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/absorption_amount/
 # プレイヤーNBT（モブ汎用NBT系）、吸収効果によって追加される「追加体力」の数
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].AbsorptionAmount set from entity @s AbsorptionAmount

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/active_effects/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/active_effects/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/active_effects/
 # プレイヤーNBT（モブ汎用NBT系）、付与されているエフェクト効果
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].active_effects set from entity @s active_effects

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/attributes/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/attributes/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/attributes/
 # プレイヤーNBT（モブ汎用NBT系）、属性（攻撃力、ノックバック耐性など）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].attributes set from entity @s attributes

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/brain/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/brain/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/brain/
 # プレイヤーNBT（モブ汎用NBT系）、存在するがおそらくプレイヤーは不使用
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Brain set from entity @s Brain

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/death_time/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/death_time/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/death_time/
 # プレイヤーNBT（モブ汎用NBT系）、モブが死亡してから経過した時間
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DeathTime set from entity @s DeathTime

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/fall_flying/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/fall_flying/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/fall_flying/
 # プレイヤーNBT（モブ汎用NBT系）、モブが死亡してから経過した時間
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].FallFlying set from entity @s FallFlying

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/health/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/health/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/death_time/
 # プレイヤーNBT（モブ汎用NBT系）、保有体力
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Health set from entity @s Health

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/hurt_by_timestamp/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/hurt_by_timestamp/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/hurt_by_timestamp/
 # プレイヤーNBT（モブ汎用NBT系）、ダメージを最後に受けた時刻
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].HurtByTimestamp set from entity @s HurtByTimestamp

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/hurt_time/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/hurt_time/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/hurt_time/
 # プレイヤーNBT（モブ汎用NBT系）、攻撃を受けたエンティティが赤い状態になるティック数
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].HurtTime set from entity @s HurtTime

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/left_handed/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/left_handed/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/left_handed/
 # プレイヤーNBT（モブ汎用NBT系）、左利きであるか
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].LeftHanded set from entity @s LeftHanded

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/no_ai/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/no_ai/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/no_ai/
 # プレイヤーNBT（モブ汎用NBT系）、ＡＩを無効化されているか（不使用と思われる）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].NoAI set from entity @s NoAI

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/sleeping_x/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/sleeping_x/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/sleeping_x/
 # プレイヤーNBT（モブ汎用NBT系）、エンティティが睡眠しているＸ座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SleepingX set from entity @s SleepingX

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/sleeping_y/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/sleeping_y/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/sleeping_y/
 # プレイヤーNBT（モブ汎用NBT系）、エンティティが睡眠しているＹ座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SleepingY set from entity @s SleepingY

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/sleeping_z/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/sleeping_z/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/sleeping_z/
 # プレイヤーNBT（モブ汎用NBT系）、エンティティが睡眠しているＺ座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SleepingZ set from entity @s SleepingZ

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/team/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/mob_common/team/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/mob_common/team/
 # プレイヤーNBT（モブ汎用NBT系）、エンティティが睡眠しているＺ座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Team set from entity @s Team

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/abilities/
 # プレイヤーNBT（プレイヤー固有）、様々なゲームモードに関わる状態
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].abilities set from entity @s abilities

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/fly_speed.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/fly_speed.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/abilities/fly_speed
 # プレイヤーNBT（プレイヤー固有）、プレイヤーが飛行中であるか
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].abilities.flySpeed set from entity @s abilities.flySpeed

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/flying.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/flying.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/abilities/flying
 # プレイヤーNBT（プレイヤー固有）、プレイヤーが飛行中であるか
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].abilities.flying set from entity @s abilities.flying

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/insta_build.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/insta_build.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/abilities/insta_build
 # プレイヤーNBT（プレイヤー固有）、ブロックを消耗せずに設置できるか
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].abilities.instabuild set from entity @s abilities.instabuild

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/invulnerable.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/invulnerable.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/abilities/invulnerable
 # プレイヤーNBT（プレイヤー固有）、いわゆる「クリエイティブモードの無敵」であるか
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].abilities.invulnerable set from entity @s abilities.invulnerable

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/may_build.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/may_build.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/abilities/may_build
 # プレイヤーNBT（プレイヤー固有）、ブロックを設置できるか
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].abilities.mayBuild set from entity @s abilities.mayBuild

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/may_fly.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/may_fly.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/abilities/may_fly
 # プレイヤーNBT（プレイヤー固有）、飛行できるか
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].abilities.mayfly set from entity @s abilities.mayfly

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/walk_speed.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/abilities/walk_speed.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/abilities/walk_speed
 # プレイヤーNBT（プレイヤー固有）、飛行できるか
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].abilities.walkSpeed set from entity @s abilities.walkSpeed

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/data_version/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/data_version/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/data_version/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーのNBT構造のデータバージョン
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].DataVersion set from entity @s DataVersion

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/dimension/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/dimension/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/dimension/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーが滞在しているディメンションID
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Dimension set from entity @s Dimension

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/ender_items/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/ender_items/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/ender_items/
 # プレイヤーNBT（プレイヤー固有）、エンダーチェストのインベントリ
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].EnderItems set from entity @s EnderItems

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/entered_nether_position/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/entered_nether_position/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/entered_nether_position/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーが最後にネザーに入ったオーバーワールドの座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].enteredNetherPosition set from entity @s enteredNetherPosition

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/entered_nether_position/x.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/entered_nether_position/x.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/entered_nether_position/x
 # プレイヤーNBT（プレイヤー固有）、プレイヤーが最後にネザーに入ったオーバーワールドのＸ座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].enteredNetherPosition.x set from entity @s enteredNetherPosition.x

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/entered_nether_position/y.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/entered_nether_position/y.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/entered_nether_position/y
 # プレイヤーNBT（プレイヤー固有）、プレイヤーが最後にネザーに入ったオーバーワールドのＹ座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].enteredNetherPosition.y set from entity @s enteredNetherPosition.y

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/entered_nether_position/z.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/entered_nether_position/z.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/entered_nether_position/z
 # プレイヤーNBT（プレイヤー固有）、プレイヤーが最後にネザーに入ったオーバーワールドのＺ座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].enteredNetherPosition.z set from entity @s enteredNetherPosition.z

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/food_exhaustion_level/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/food_exhaustion_level/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/food_exhaustion_level/
 # プレイヤーNBT（プレイヤー固有）、満腹度の減少度
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].foodExhaustionLevel set from entity @s foodExhaustionLevel

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/food_level/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/food_level/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/food_level/
 # プレイヤーNBT（プレイヤー固有）、満腹度
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].foodLevel set from entity @s foodLevel

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/food_saturation_level/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/food_saturation_level/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/food_saturation_level/
 # プレイヤーNBT（プレイヤー固有）、隠し満腹度
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].foodSaturationLevel set from entity @s foodSaturationLevel

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/food_tick_timer/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/food_tick_timer/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/food_tick_timer/
 # プレイヤーNBT（プレイヤー固有）、満腹度に関わるタイマー
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].foodTickTimer set from entity @s foodTickTimer

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/inventory/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/inventory/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/inventory/
 # プレイヤーNBT（プレイヤー固有）、インベントリ
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Inventory set from entity @s Inventory

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/last_death_location/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/last_death_location/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/last_death_location/
 # プレイヤーNBT（プレイヤー固有）、最後の死亡地点
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].LastDeathLocation set from entity @s LastDeathLocation

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/last_death_location/dimension.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/last_death_location/dimension.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/last_death_location/dimension
 # プレイヤーNBT（プレイヤー固有）、最後に死亡したディメンション
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].LastDeathLocation.dimension set from entity @s LastDeathLocation.dimension

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/last_death_location/pos.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/last_death_location/pos.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/last_death_location/pos
 # プレイヤーNBT（プレイヤー固有）、最後の死亡地点の座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].LastDeathLocation.pos set from entity @s LastDeathLocation.pos

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/last_death_location/posx.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/last_death_location/posx.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/last_death_location/posx
 # プレイヤーNBT（プレイヤー固有）、最後の死亡地点のＸ座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].LastDeathLocation.pos[0] set from entity @s LastDeathLocation.pos[0]

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/last_death_location/posy.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/last_death_location/posy.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/last_death_location/posy
 # プレイヤーNBT（プレイヤー固有）、最後の死亡地点のＹ座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].LastDeathLocation.pos[1] set from entity @s LastDeathLocation.pos[1]

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/last_death_location/posz.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/last_death_location/posz.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/last_death_location/posz
 # プレイヤーNBT（プレイヤー固有）、最後の死亡地点のＺ座標
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].LastDeathLocation.pos[2] set from entity @s LastDeathLocation.pos[2]

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/player_game_type/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/player_game_type/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/player_game_type/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーのゲームモード
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].playerGameType set from entity @s playerGameType

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/previous_player_game_type/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/previous_player_game_type/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/previous_player_game_type/
 # プレイヤーNBT（プレイヤー固有）、直前に設定されていたプレイヤーのゲームモード
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].previousPlayerGameType set from entity @s previousPlayerGameType

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/recipe_book/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/recipe_book/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/recipe_book/
 # プレイヤーNBT（プレイヤー固有）、直前に設定されていたプレイヤーのゲームモード
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].recipeBook set from entity @s recipeBook

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/root_vehicle/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/root_vehicle/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/root_vehicle/
 # プレイヤーNBT（プレイヤー固有）、プレイヤー「が」騎乗しているエンティティ
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].RootVehicle set from entity @s RootVehicle

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/root_vehicle/attach.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/root_vehicle/attach.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/root_vehicle/attach
 # プレイヤーNBT（プレイヤー固有）、プレイヤー「が」騎乗しているエンティティの「ＵＵＩＤ」
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].RootVehicle.Attach set from entity @s RootVehicle.Attach

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/root_vehicle/entity.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/root_vehicle/entity.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/root_vehicle/entity
 # プレイヤーNBT（プレイヤー固有）、プレイヤー「が」騎乗しているエンティティのNBTデータ
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].RootVehicle.Entity set from entity @s RootVehicle.Entity

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/score/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/score/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/score/
 # プレイヤーNBT（プレイヤー固有）、死亡時に表示されるスコア
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].Score set from entity @s Score

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/seen_credits/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/seen_credits/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/seen_credits/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーがすでにスタッフクレジットを見ているか
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].seenCredits set from entity @s seenCredits

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/selected_item/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/selected_item/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/selected_item/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーが現在手に持っているアイテム
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SelectedItem set from entity @s SelectedItem

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/selected_item_slot/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/selected_item_slot/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/selected_item_slot/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーが現在手に持っているアイテムのスロット番号
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SelectedItemSlot set from entity @s SelectedItemSlot

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/shoulder_entity_left/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/shoulder_entity_left/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/shoulder_entity_left/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーが左肩に乗せているエンティティ（オウムとして表示されます）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ShoulderEntityLeft set from entity @s ShoulderEntityLeft

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/shoulder_entity_right/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/shoulder_entity_right/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/shoulder_entity_right/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーが右肩に乗せているエンティティ（オウムとして表示されます）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].ShoulderEntityRight set from entity @s ShoulderEntityRight

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/sleep_timer/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/sleep_timer/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/sleep_timer/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーがベッドに滞在した時間
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SleepTimer set from entity @s SleepTimer

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/spawn_dimension/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/spawn_dimension/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/spawn_dimension/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーのリスポーン地点のディメンション
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SpawnDimension set from entity @s SpawnDimension

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/spawn_forced/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/spawn_forced/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/spawn_forced/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーに該当するベッドやリスポーンアンカーが見つかったか
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SpawnForced set from entity @s SpawnForced

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/spawn_x/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/spawn_x/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/spawn_x/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーの初期スポーン地点（Ｘ座標）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SpawnX set from entity @s SpawnX

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/spawn_y/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/spawn_y/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/spawn_y/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーの初期スポーン地点（Ｙ座標）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SpawnY set from entity @s SpawnY

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/spawn_z/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/spawn_z/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/spawn_z/
 # プレイヤーNBT（プレイヤー固有）、プレイヤーの初期スポーン地点（Ｚ座標）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].SpawnZ set from entity @s SpawnZ

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/warden_spawn_tracker/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/warden_spawn_tracker/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/warden_spawn_tracker/
 # プレイヤーNBT（プレイヤー固有）、ウォーデンのスポーン関係のNBT
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].warden_spawn_tracker set from entity @s warden_spawn_tracker

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/warden_spawn_tracker/cooldown_ticks.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/warden_spawn_tracker/cooldown_ticks.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/warden_spawn_tracker/cooldown_ticks
 # プレイヤーNBT（プレイヤー固有）、ウォーデンのスポーン関係のNBT（警戒レベルが再度増加するまでに必要なティック数）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].warden_spawn_tracker.cooldown_ticks set from entity @s warden_spawn_tracker.cooldown_ticks

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/warden_spawn_tracker/ticks_since_last_warning.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/warden_spawn_tracker/ticks_since_last_warning.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/warden_spawn_tracker/ticks_since_last_warning
 # プレイヤーNBT（プレイヤー固有）、ウォーデンのスポーン関係のNBT（ウォーデン出現を警告されてからの経過ティック数）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].warden_spawn_tracker.ticks_since_last_warning set from entity @s warden_spawn_tracker.ticks_since_last_warning

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/warden_spawn_tracker/warning_level.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/warden_spawn_tracker/warning_level.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/warden_spawn_tracker/warning_level
 # プレイヤーNBT（プレイヤー固有）、ウォーデンのスポーン関係のNBT（警戒レベル）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].warden_spawn_tracker.warning_level set from entity @s warden_spawn_tracker.warning_level

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/xp_level/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/xp_level/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/xp_level/
 # プレイヤーNBT（プレイヤー固有）、経験値バーに表示されるレベル
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].XpLevel set from entity @s XpLevel

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/xp_p/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/xp_p/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/xp_p/
 # プレイヤーNBT（プレイヤー固有）、経験値バーの進行度（パーセンテージ）
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].XpP set from entity @s XpP

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/xp_seed/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/xp_seed/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/xp_seed/
 # プレイヤーNBT（プレイヤー固有）、エンチャント テーブルで次のエンチャントに使用されるシード値。
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].XpSeed set from entity @s XpSeed

--- a/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/xp_total/.mcfunction
+++ b/TUSBAD_Prototype/data/player_manager/function/update/player_dat/player_common/xp_total/.mcfunction
@@ -1,6 +1,6 @@
 #> player_manager:update/player_dat/player_common/xp_total/
 # プレイヤーNBT（プレイヤー固有）、現在獲得している経験値量
 
-function oh_my_dat:please
+function #oh_my_dat:please
 
 data modify storage oh_my_dat: _[-4][-4][-4][-4][-4][-4][-4][-4].XpTotal set from entity @s XpTotal


### PR DESCRIPTION
・現状
「取り返す」以外の墓システムは仕様書通りに制作できたと思います

・および、前回のプレイヤーデータ保存処理に使われているoh_my_datの呼び出しで最初に「#」がついていなかったので
改めて呼び出し処理に「＃」を付けました。